### PR TITLE
Feature metadata validation

### DIFF
--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
@@ -1,0 +1,22 @@
+package com.tdei.filesvc.common.model;
+
+public enum MetaErrorCodes {
+
+    INVALID_COLLECTEDBY_LENGTH(4000),
+    NO_COLLECTION_DATE(4001),
+    COLLECTION_DATE_FUTURE(4002),
+    NO_COLLECTION_METHOD(4003),
+    INVALID_COLLECTION_METHOD(4004),
+    NO_DATA_SOURCE(4005),
+    INVALID_DATA_SOURCE(4006);
+
+
+    private final int status;
+    MetaErrorCodes(int status) {
+        this.status = status;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
@@ -8,7 +8,11 @@ public enum MetaErrorCodes {
     NO_COLLECTION_METHOD(4003),
     INVALID_COLLECTION_METHOD(4004),
     NO_DATA_SOURCE(4005),
-    INVALID_DATA_SOURCE(4006);
+    INVALID_DATA_SOURCE(4006),
+
+    NO_FLEX_SCHEMA(4007),
+
+    INVALID_FLEX_SCHEMA(4008);
 
 
     private final int status;

--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorCodes.java
@@ -12,8 +12,11 @@ public enum MetaErrorCodes {
 
     NO_FLEX_SCHEMA(4007),
 
-    INVALID_FLEX_SCHEMA(4008);
+    INVALID_FLEX_SCHEMA(4008),
 
+    NO_GTFS_PATHWAY_SCHEMA(6001),
+    INVALID_GTFS_PATHWAY_SCHEMA(6002)
+    ;
 
     private final int status;
     MetaErrorCodes(int status) {

--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
@@ -1,0 +1,13 @@
+package com.tdei.filesvc.common.model;
+
+public interface MetaErrorMessages {
+
+    String INVALID_DATA_SOURCE = "data_source should be one of the following `3rdParty`,`TDEITools`,`InHouse`";
+    String INVALID_COLLECTION_METHOD = "collection_method needs to be one of the following `manual`,`transform`,`generated`,`other`";
+
+    String COLLECTION_DATE_FUTURE = "collection_date cannot be future";
+
+    String NO_COLLECTION_DATE = "collection_date is invalid";
+
+    String COLLECTED_BY_LENGTHY = "collected_by should be less than 50 characters";
+}

--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
@@ -10,4 +10,8 @@ public interface MetaErrorMessages {
     String NO_COLLECTION_DATE = "collection_date is invalid";
 
     String COLLECTED_BY_LENGTHY = "collected_by should be less than 50 characters";
+
+    String NO_FLEX_VERSION = "flex_schema_version not specified";
+
+    String INVALID_FLEX_VERSION = "invalid flex_schema_version. Valid one `v2.0`";
 }

--- a/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaErrorMessages.java
@@ -14,4 +14,8 @@ public interface MetaErrorMessages {
     String NO_FLEX_VERSION = "flex_schema_version not specified";
 
     String INVALID_FLEX_VERSION = "invalid flex_schema_version. Valid one `v2.0`";
+
+    String NO_GTFS_PATHWAY_VERSION = "pathways_schema_version not specified";
+
+    String INVALID_GTFS_PATHWAY_VERSION = "invalid pathways_schema_version. Valid one `v1.0`";
 }

--- a/src/main/java/com/tdei/filesvc/common/model/MetaValidationError.java
+++ b/src/main/java/com/tdei/filesvc/common/model/MetaValidationError.java
@@ -1,0 +1,46 @@
+package com.tdei.filesvc.common.model;
+
+/**
+ * Validation error generated when there is a metadata validation error.
+ *
+ */
+public class MetaValidationError extends  Error {
+    String errorName;
+    String errorDescription;
+
+    MetaErrorCodes code;
+
+    public MetaValidationError(String errorName, String errorDescription) {
+        this.errorName = errorName;
+        this.errorDescription = errorDescription;
+    }
+
+    public MetaValidationError(MetaErrorCodes code, String errorDescription) {
+        this.code = code;
+        this.errorDescription = errorDescription;
+    }
+
+    public String getErrorName() {
+        return errorName;
+    }
+
+    public void setErrorName(String errorName) {
+        this.errorName = errorName;
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
+    public void setErrorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+
+    public MetaErrorCodes getCode() {
+        return code;
+    }
+
+    public void setCode(MetaErrorCodes code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/com/tdei/filesvc/core/config/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tdei/filesvc/core/config/exception/handler/GlobalExceptionHandler.java
@@ -164,7 +164,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         List<String> errors = new ArrayList<>();
         ex.getErrorList().forEach(x->{
-            errors.add(x.getMessage());
+            errors.add(x.getErrorDescription());
         });
 
         ApiError err = new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, ex.getMessage(), errors);

--- a/src/main/java/com/tdei/filesvc/core/config/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tdei/filesvc/core/config/exception/handler/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.tdei.filesvc.core.config.exception.handler;
 
-import com.tdei.filesvc.core.config.exception.handler.exceptions.FileExtensionNotAllowedException;
-import com.tdei.filesvc.core.config.exception.handler.exceptions.InvalidAccessTokenException;
-import com.tdei.filesvc.core.config.exception.handler.exceptions.InvalidCredentialsException;
-import com.tdei.filesvc.core.config.exception.handler.exceptions.ResourceNotFoundException;
+import com.tdei.filesvc.core.config.exception.handler.exceptions.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -158,6 +155,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         details.add(ex.getMessage());
 
         ApiError err = new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, "File Type Not Supported", details);
+
+        return ResponseEntityBuilder.build(err);
+    }
+
+    @ExceptionHandler(MetadataValidationException.class)
+    public ResponseEntity<Object> handleMetadataValidationException(MetadataValidationException ex) {
+
+        List<String> errors = new ArrayList<>();
+        ex.getErrorList().forEach(x->{
+            errors.add(x.getMessage());
+        });
+
+        ApiError err = new ApiError(LocalDateTime.now(), HttpStatus.BAD_REQUEST, ex.getMessage(), errors);
 
         return ResponseEntityBuilder.build(err);
     }

--- a/src/main/java/com/tdei/filesvc/core/config/exception/handler/exceptions/MetadataValidationException.java
+++ b/src/main/java/com/tdei/filesvc/core/config/exception/handler/exceptions/MetadataValidationException.java
@@ -1,0 +1,20 @@
+package com.tdei.filesvc.core.config.exception.handler.exceptions;
+
+import com.tdei.filesvc.common.model.MetaValidationError;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+@Data
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class MetadataValidationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private List<MetaValidationError> errorList;
+
+    public MetadataValidationException(String message, List<MetaValidationError> errorList) {
+        super(message);
+        this.errorList = errorList;
+    }
+}

--- a/src/main/java/com/tdei/filesvc/gtfsflex/controller/GtfsFlexFileController.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/controller/GtfsFlexFileController.java
@@ -1,5 +1,6 @@
 package com.tdei.filesvc.gtfsflex.controller;
 
+import com.tdei.filesvc.common.model.MetaValidationError;
 import com.tdei.filesvc.gtfsflex.controller.contract.IGtfsFlexFileController;
 import com.tdei.filesvc.gtfsflex.model.GtfsFlexUpload;
 import com.tdei.filesvc.gtfsflex.service.GtfsFlexStorageService;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +25,13 @@ public class GtfsFlexFileController implements IGtfsFlexFileController {
 
     @Override
     public ResponseEntity<String> uploadGtfsFlexFile(GtfsFlexUpload meta, String tdeiOrgId, String userId, MultipartFile file, HttpServletRequest httpServletRequest) throws FileUploadException {
-        return ResponseEntity.ok(storageService.uploadBlob(meta, tdeiOrgId, userId, file));
+        List<MetaValidationError> metaValidationErrors = meta.isMetadataValidated();
+        if(metaValidationErrors.isEmpty()) {
+            return ResponseEntity.ok(storageService.uploadBlob(meta, tdeiOrgId, userId, file));
+        }
+        else {
+            // Send the validation errors
+            return  ResponseEntity.badRequest().build(); //TODO: change this
+        }
     }
 }

--- a/src/main/java/com/tdei/filesvc/gtfsflex/controller/GtfsFlexFileController.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/controller/GtfsFlexFileController.java
@@ -1,6 +1,7 @@
 package com.tdei.filesvc.gtfsflex.controller;
 
 import com.tdei.filesvc.common.model.MetaValidationError;
+import com.tdei.filesvc.core.config.exception.handler.exceptions.MetadataValidationException;
 import com.tdei.filesvc.gtfsflex.controller.contract.IGtfsFlexFileController;
 import com.tdei.filesvc.gtfsflex.model.GtfsFlexUpload;
 import com.tdei.filesvc.gtfsflex.service.GtfsFlexStorageService;
@@ -31,7 +32,7 @@ public class GtfsFlexFileController implements IGtfsFlexFileController {
         }
         else {
             // Send the validation errors
-            return  ResponseEntity.badRequest().build(); //TODO: change this
+            throw new MetadataValidationException("Error validating Metadata",metaValidationErrors);
         }
     }
 }

--- a/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
@@ -3,11 +3,8 @@ package com.tdei.filesvc.gtfsflex.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.filesvc.common.model.GeoJsonObject;
-import com.ctc.wstx.util.StringUtil;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.filesvc.common.model.MetaErrorMessages;
 import com.tdei.filesvc.common.model.MetaValidationError;
-import com.tdei.filesvc.common.model.Polygon;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
@@ -15,7 +12,6 @@ import org.springframework.validation.annotation.Validated;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -96,7 +92,7 @@ public class GtfsFlexUpload {
             MetaValidationError collectionDateError = new MetaValidationError(NO_COLLECTION_DATE,MetaErrorMessages.NO_COLLECTION_DATE);
             errors.add(collectionDateError);
         }
-       else if(this.getCollectionDate().isAfter(OffsetDateTime.now())){
+       else if(this.getCollectionDate().isAfter(LocalDateTime.now())){
             // Cannot be future date
             MetaValidationError collectionDateError = new MetaValidationError(COLLECTION_DATE_FUTURE,MetaErrorMessages.COLLECTION_DATE_FUTURE);
             errors.add(collectionDateError);

--- a/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
@@ -128,6 +128,14 @@ public class GtfsFlexUpload {
                 errors.add(invalidDatasourceError);
             }
         }
+        if(this.getFlexSchemaVersion() == null){
+            MetaValidationError noFlexSchemaError = new MetaValidationError(NO_FLEX_SCHEMA,MetaErrorMessages.NO_FLEX_VERSION);
+            errors.add(noFlexSchemaError);
+        }
+        else if(!this.getFlexSchemaVersion().equals("v2.0")){ // To be shifted to other service soon
+            MetaValidationError invalidFlexSchemaError = new MetaValidationError(INVALID_FLEX_SCHEMA,MetaErrorMessages.INVALID_FLEX_VERSION);
+            errors.add(invalidFlexSchemaError);
+        }
 
          return errors;
     }

--- a/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
@@ -28,7 +28,7 @@ public class GtfsFlexUpload {
     @JsonProperty("tdei_service_id")
     private String tdeiServiceId = null;
 
-    @Schema(required = true, description = "Description of who data was collected by. See Best Practices document for information on how to format this string.")
+    @Schema(required = true,description = "Description of who data was collected by. See Best Practices document for information on how to format this string.")
     @NotNull
     @JsonProperty("collected_by")
     private String collectedBy = null;
@@ -72,4 +72,8 @@ public class GtfsFlexUpload {
     @NotNull
     @JsonProperty("flex_schema_version")
     private String flexSchemaVersion = null;
+
+    public boolean isMetadataValidated(){
+        return this.getCollectedBy().length() <= 50;
+    }
 }

--- a/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
+++ b/src/main/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUpload.java
@@ -3,6 +3,11 @@ package com.tdei.filesvc.gtfsflex.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tdei.filesvc.common.model.GeoJsonObject;
+import com.ctc.wstx.util.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tdei.filesvc.common.model.MetaErrorMessages;
+import com.tdei.filesvc.common.model.MetaValidationError;
+import com.tdei.filesvc.common.model.Polygon;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import org.springframework.validation.annotation.Validated;
@@ -10,6 +15,11 @@ import org.springframework.validation.annotation.Validated;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.tdei.filesvc.common.model.MetaErrorCodes.*;
 
 /**
  * Represents meta data needed to upload a gtfs_flex data file
@@ -73,7 +83,56 @@ public class GtfsFlexUpload {
     @JsonProperty("flex_schema_version")
     private String flexSchemaVersion = null;
 
-    public boolean isMetadataValidated(){
-        return this.getCollectedBy().length() <= 50;
+    public List<MetaValidationError> isMetadataValidated(){
+        ArrayList<MetaValidationError> errors = new ArrayList<>();
+
+        // Collected By
+        if(this.getCollectedBy().length() > 50){
+            MetaValidationError collectedByError = new MetaValidationError(INVALID_COLLECTEDBY_LENGTH, MetaErrorMessages.COLLECTED_BY_LENGTHY);//new MetaValidationError("Invalid length","collected_by should be less than 50 characters");
+            errors.add(collectedByError);
+        }
+        // Collection date
+        if(this.getCollectionDate() == null){
+            MetaValidationError collectionDateError = new MetaValidationError(NO_COLLECTION_DATE,MetaErrorMessages.NO_COLLECTION_DATE);
+            errors.add(collectionDateError);
+        }
+       else if(this.getCollectionDate().isAfter(OffsetDateTime.now())){
+            // Cannot be future date
+            MetaValidationError collectionDateError = new MetaValidationError(COLLECTION_DATE_FUTURE,MetaErrorMessages.COLLECTION_DATE_FUTURE);
+            errors.add(collectionDateError);
+        }
+
+       // Collection method
+        if(this.getCollectionMethod() == null){
+            MetaValidationError collectionMethodError = new MetaValidationError(NO_COLLECTION_METHOD,MetaErrorMessages.INVALID_COLLECTION_METHOD);
+            errors.add(collectionMethodError);
+        }
+        else {
+            String collectionMethodLowerCase = this.getCollectionMethod().toLowerCase();
+            List<String> validCollectionMethods = new ArrayList<>(
+                    List.of("manual",
+                            "transform",
+                            "generated",
+                            "other"));
+            if(!validCollectionMethods.contains(collectionMethodLowerCase)){
+                MetaValidationError invalidCollectionMethodError = new MetaValidationError(INVALID_COLLECTION_METHOD,MetaErrorMessages.INVALID_COLLECTION_METHOD);
+                errors.add(invalidCollectionMethodError);
+            }
+        }
+
+        // Data source
+        if(this.getDataSource() == null){
+            MetaValidationError datasourceError = new MetaValidationError(NO_DATA_SOURCE,MetaErrorMessages.INVALID_DATA_SOURCE);
+            errors.add(datasourceError);
+        }
+        else {
+            List<String> validDataSource = new ArrayList<>(List.of("3rdParty","TDEITools","InHouse"));
+            if(!validDataSource.contains(this.getDataSource())){
+                MetaValidationError invalidDatasourceError = new MetaValidationError(INVALID_DATA_SOURCE,MetaErrorMessages.INVALID_DATA_SOURCE);
+                errors.add(invalidDatasourceError);
+            }
+        }
+
+         return errors;
     }
 }

--- a/src/main/java/com/tdei/filesvc/gtfspathways/controller/GtfsPathwaysFileController.java
+++ b/src/main/java/com/tdei/filesvc/gtfspathways/controller/GtfsPathwaysFileController.java
@@ -1,6 +1,7 @@
 package com.tdei.filesvc.gtfspathways.controller;
 
 import com.tdei.filesvc.common.model.MetaValidationError;
+import com.tdei.filesvc.core.config.exception.handler.exceptions.MetadataValidationException;
 import com.tdei.filesvc.gtfspathways.controller.contract.IGtfsPathwaysFileController;
 import com.tdei.filesvc.gtfspathways.model.GtfsPathwaysUpload;
 import com.tdei.filesvc.gtfspathways.service.GtfsPathwaysStorageService;
@@ -30,7 +31,7 @@ public class GtfsPathwaysFileController implements IGtfsPathwaysFileController {
             return ResponseEntity.ok(storageService.uploadBlob(meta, tdeiOrgId, userId, file));
         }
         else {
-            return ResponseEntity.badRequest().build();//TODO: Change this
+           throw  new MetadataValidationException("Error validating metadata",errorList);
         }
     }
 

--- a/src/main/java/com/tdei/filesvc/gtfspathways/controller/GtfsPathwaysFileController.java
+++ b/src/main/java/com/tdei/filesvc/gtfspathways/controller/GtfsPathwaysFileController.java
@@ -1,5 +1,6 @@
 package com.tdei.filesvc.gtfspathways.controller;
 
+import com.tdei.filesvc.common.model.MetaValidationError;
 import com.tdei.filesvc.gtfspathways.controller.contract.IGtfsPathwaysFileController;
 import com.tdei.filesvc.gtfspathways.model.GtfsPathwaysUpload;
 import com.tdei.filesvc.gtfspathways.service.GtfsPathwaysStorageService;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,7 +25,13 @@ public class GtfsPathwaysFileController implements IGtfsPathwaysFileController {
 
     @Override
     public ResponseEntity<String> uploadGtfsPathwaysFile(GtfsPathwaysUpload meta, String tdeiOrgId, String userId, MultipartFile file, HttpServletRequest httpServletRequest) throws FileUploadException {
-        return ResponseEntity.ok(storageService.uploadBlob(meta, tdeiOrgId, userId, file));
+        List<MetaValidationError> errorList  = meta.isMetadataValidated();
+        if(errorList.isEmpty()) {
+            return ResponseEntity.ok(storageService.uploadBlob(meta, tdeiOrgId, userId, file));
+        }
+        else {
+            return ResponseEntity.badRequest().build();//TODO: Change this
+        }
     }
 
 }

--- a/src/test/java/com/tdei/filesvc/GtfsFlexTests.java
+++ b/src/test/java/com/tdei/filesvc/GtfsFlexTests.java
@@ -86,10 +86,14 @@ class GtfsFlexTests {
         props.setGtfsFlex(gtfsFlexProperties);
 
         String orgId = "101";
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("morethan50chars");
+        boolean isMetaValid = upload.isMetadataValidated();
+        assertThat(isMetaValid).isTrue();
         when(storageService.uploadBlob(any(MockMultipartFile.class), anyString(), anyString())).thenReturn("success");
         when(applicationProperties.getGtfsFlex()).thenReturn(props.getGtfsFlex());
         doNothing().when(eventBusService).sendMessage(any(QueueMessage.class), anyString());
-        var result = gtfsFlexStorageServiceInjectMock.uploadBlob(new GtfsFlexUpload(), orgId, "2039-2829", file);
+        var result = gtfsFlexStorageServiceInjectMock.uploadBlob(upload, orgId, "2039-2829", file);
 
         assertThat(result).isNotBlank();
     }

--- a/src/test/java/com/tdei/filesvc/GtfsFlexTests.java
+++ b/src/test/java/com/tdei/filesvc/GtfsFlexTests.java
@@ -86,14 +86,11 @@ class GtfsFlexTests {
         props.setGtfsFlex(gtfsFlexProperties);
 
         String orgId = "101";
-        GtfsFlexUpload upload = new GtfsFlexUpload();
-        upload.setCollectedBy("morethan50chars");
-        boolean isMetaValid = upload.isMetadataValidated();
-        assertThat(isMetaValid).isTrue();
+
         when(storageService.uploadBlob(any(MockMultipartFile.class), anyString(), anyString())).thenReturn("success");
         when(applicationProperties.getGtfsFlex()).thenReturn(props.getGtfsFlex());
         doNothing().when(eventBusService).sendMessage(any(QueueMessage.class), anyString());
-        var result = gtfsFlexStorageServiceInjectMock.uploadBlob(upload, orgId, "2039-2829", file);
+        var result = gtfsFlexStorageServiceInjectMock.uploadBlob(new GtfsFlexUpload(), orgId, "2039-2829", file);
 
         assertThat(result).isNotBlank();
     }

--- a/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
+++ b/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
@@ -1,0 +1,12 @@
+package com.tdei.filesvc.gtfsflex.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+ class GtfsFlexUploadTests {
+
+    @Test
+
+}

--- a/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
+++ b/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
@@ -1,12 +1,74 @@
 package com.tdei.filesvc.gtfsflex.model;
 
+import com.tdei.filesvc.common.model.MetaValidationError;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(MockitoExtension.class)
  class GtfsFlexUploadTests {
 
     @Test
+    void testCollectedBy(){
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("morethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50chars");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+    }
+
+    @Test
+    void testCollectionDate(){
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("collectedBy");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+        // Get the first error
+        MetaValidationError invalidDateError = errors.get(0);
+        assertThat(invalidDateError.getErrorName()).isEqualTo("Invalid format");
+
+        // Assert for future dates in collection date
+        upload.setCollectionDate(OffsetDateTime.now().plusHours(2));
+        List<MetaValidationError> metaErrors = upload.isMetadataValidated();
+        assertThat(metaErrors.size()).isNotEqualTo(0);
+        MetaValidationError futureError = metaErrors.get(0);
+        assertThat(futureError.getErrorName()).isEqualTo("Invalid collection date");
+    }
+
+    @Test
+    void testCollectionMethod() {
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(OffsetDateTime.now());
+        // No collection_method
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isEqualTo(1);
+
+        // invalid collection method
+        upload.setCollectionMethod("junkmethod");
+        List<MetaValidationError> invalidCollectionMethod = upload.isMetadataValidated();
+        assertThat(invalidCollectionMethod.size()).isNotEqualTo(0);
+
+        // valid one
+        upload.setCollectionMethod("other"); // Can be replaced with `manual`,`transform`,`generated`
+        List<MetaValidationError> validCollectionMethod = upload.isMetadataValidated();
+        assertThat(validCollectionMethod.size()).isEqualTo(0);
+    }
+
+    @Test
+    void testDataSource(){
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(OffsetDateTime.now());
+        upload.setCollectionMethod("other");
+
+
+    }
+
+
 
 }

--- a/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
+++ b/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -32,7 +32,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
         assertThat(invalidDateError.getErrorName()).isEqualTo("Invalid format");
 
         // Assert for future dates in collection date
-        upload.setCollectionDate(OffsetDateTime.now().plusHours(2));
+        upload.setCollectionDate(LocalDateTime.now().plusHours(2));
         List<MetaValidationError> metaErrors = upload.isMetadataValidated();
         assertThat(metaErrors.size()).isNotEqualTo(0);
         MetaValidationError futureError = metaErrors.get(0);
@@ -43,7 +43,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     void testCollectionMethod() {
         GtfsFlexUpload upload = new GtfsFlexUpload();
         upload.setCollectedBy("collectedBy");
-        upload.setCollectionDate(OffsetDateTime.now());
+        upload.setCollectionDate(LocalDateTime.now());
         // No collection_method
         List<MetaValidationError> errors = upload.isMetadataValidated();
         assertThat(errors.size()).isEqualTo(1);
@@ -63,7 +63,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     void testDataSource(){
         GtfsFlexUpload upload = new GtfsFlexUpload();
         upload.setCollectedBy("collectedBy");
-        upload.setCollectionDate(OffsetDateTime.now());
+        upload.setCollectionDate(LocalDateTime.now());
         upload.setCollectionMethod("other");
 
 

--- a/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
+++ b/src/test/java/com/tdei/filesvc/gtfsflex/model/GtfsFlexUploadTests.java
@@ -1,5 +1,6 @@
 package com.tdei.filesvc.gtfsflex.model;
 
+import com.tdei.filesvc.common.model.MetaErrorCodes;
 import com.tdei.filesvc.common.model.MetaValidationError;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.tdei.filesvc.common.model.MetaErrorCodes.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,6 +21,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
         upload.setCollectedBy("morethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50chars");
         List<MetaValidationError> errors = upload.isMetadataValidated();
         assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError firstError = errors.get(0);
+        assertThat(firstError.getCode()).isEqualTo(INVALID_COLLECTEDBY_LENGTH);
     }
 
     @Test
@@ -29,14 +33,14 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
         assertThat(errors.size()).isNotEqualTo(0);
         // Get the first error
         MetaValidationError invalidDateError = errors.get(0);
-        assertThat(invalidDateError.getErrorName()).isEqualTo("Invalid format");
+        assertThat(invalidDateError.getCode()).isEqualTo(NO_COLLECTION_DATE);
 
         // Assert for future dates in collection date
         upload.setCollectionDate(LocalDateTime.now().plusHours(2));
         List<MetaValidationError> metaErrors = upload.isMetadataValidated();
         assertThat(metaErrors.size()).isNotEqualTo(0);
         MetaValidationError futureError = metaErrors.get(0);
-        assertThat(futureError.getErrorName()).isEqualTo("Invalid collection date");
+        assertThat(futureError.getCode()).isEqualTo(COLLECTION_DATE_FUTURE);
     }
 
     @Test
@@ -44,14 +48,20 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
         GtfsFlexUpload upload = new GtfsFlexUpload();
         upload.setCollectedBy("collectedBy");
         upload.setCollectionDate(LocalDateTime.now());
+        upload.setDataSource("3rdParty");
+        upload.setFlexSchemaVersion("v2.0");
         // No collection_method
         List<MetaValidationError> errors = upload.isMetadataValidated();
-        assertThat(errors.size()).isEqualTo(1);
+        assertThat(errors.size()).isNotEqualTo(0);
+
 
         // invalid collection method
         upload.setCollectionMethod("junkmethod");
         List<MetaValidationError> invalidCollectionMethod = upload.isMetadataValidated();
         assertThat(invalidCollectionMethod.size()).isNotEqualTo(0);
+        // method to be invalid collection method
+        MetaValidationError metaValidationError = invalidCollectionMethod.get(0);
+        assertThat(metaValidationError.getCode()).isEqualTo(INVALID_COLLECTION_METHOD);
 
         // valid one
         upload.setCollectionMethod("other"); // Can be replaced with `manual`,`transform`,`generated`
@@ -65,6 +75,46 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
         upload.setCollectedBy("collectedBy");
         upload.setCollectionDate(LocalDateTime.now());
         upload.setCollectionMethod("other");
+        upload.setFlexSchemaVersion("v2.0");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError noDataSourceError = errors.get(0);
+        assertThat(noDataSourceError.getCode()).isEqualTo(NO_DATA_SOURCE);
+        // Invalid datasource
+        upload.setDataSource("testdatasource");
+        List<MetaValidationError> dsErrors = upload.isMetadataValidated();
+        assertThat(dsErrors.size()).isNotEqualTo(0);
+        MetaValidationError invalidDatasourceError = dsErrors.get(0);
+        assertThat(invalidDatasourceError.getCode()).isEqualTo(INVALID_DATA_SOURCE);
+
+        // valid datasource
+        upload.setDataSource("3rdParty");
+        List<MetaValidationError> noErrors = upload.isMetadataValidated();
+        assertThat(noErrors.size()).isEqualTo(0);
+    }
+
+
+    @Test
+    void testVersionSchema(){
+        GtfsFlexUpload upload = new GtfsFlexUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(LocalDateTime.now());
+        upload.setCollectionMethod("other");
+        upload.setDataSource("3rdParty");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+
+        assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError noSchemaError = errors.get(0);
+        assertThat(noSchemaError.getCode()).isEqualTo(NO_FLEX_SCHEMA);
+        // invalid schema version
+        upload.setFlexSchemaVersion("v1.0");
+        List<MetaValidationError> invalidSchemaErrors = upload.isMetadataValidated();
+        assertThat(invalidSchemaErrors.size()).isNotEqualTo(0);
+        MetaValidationError invalidSchemaError = invalidSchemaErrors.get(0);
+        assertThat(invalidSchemaError.getCode()).isEqualTo(INVALID_FLEX_SCHEMA);
+        upload.setFlexSchemaVersion("v2.0");
+        List<MetaValidationError> noErrors = upload.isMetadataValidated();
+        assertThat(noErrors.size()).isEqualTo(0);
 
 
     }

--- a/src/test/java/com/tdei/filesvc/gtfspathways/model/GtfsPathwaysUploadTests.java
+++ b/src/test/java/com/tdei/filesvc/gtfspathways/model/GtfsPathwaysUploadTests.java
@@ -1,0 +1,117 @@
+package com.tdei.filesvc.gtfspathways.model;
+
+import com.tdei.filesvc.common.model.MetaValidationError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.tdei.filesvc.common.model.MetaErrorCodes.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class GtfsPathwaysUploadTests {
+    @Test
+    void testCollectedBy(){
+        GtfsPathwaysUpload upload = new GtfsPathwaysUpload();
+        upload.setCollectedBy("morethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50charsmorethan50chars");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError firstError = errors.get(0);
+        assertThat(firstError.getCode()).isEqualTo(INVALID_COLLECTEDBY_LENGTH);
+    }
+
+    @Test
+    void testCollectionDate(){
+        GtfsPathwaysUpload upload = new GtfsPathwaysUpload();
+        upload.setCollectedBy("collectedBy");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+        // Get the first error
+        MetaValidationError invalidDateError = errors.get(0);
+        assertThat(invalidDateError.getCode()).isEqualTo(NO_COLLECTION_DATE);
+
+        // Assert for future dates in collection date
+        upload.setCollectionDate(LocalDateTime.now().plusHours(2));
+        List<MetaValidationError> metaErrors = upload.isMetadataValidated();
+        assertThat(metaErrors.size()).isNotEqualTo(0);
+        MetaValidationError futureError = metaErrors.get(0);
+        assertThat(futureError.getCode()).isEqualTo(COLLECTION_DATE_FUTURE);
+    }
+
+    @Test
+    void testCollectionMethod() {
+        GtfsPathwaysUpload upload = new GtfsPathwaysUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(LocalDateTime.now());
+        upload.setDataSource("3rdParty");
+        upload.setPathwaysSchemaVersion("v1.0");
+        // No collection_method
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+
+
+        // invalid collection method
+        upload.setCollectionMethod("junkmethod");
+        List<MetaValidationError> invalidCollectionMethod = upload.isMetadataValidated();
+        assertThat(invalidCollectionMethod.size()).isNotEqualTo(0);
+        // method to be invalid collection method
+        MetaValidationError metaValidationError = invalidCollectionMethod.get(0);
+        assertThat(metaValidationError.getCode()).isEqualTo(INVALID_COLLECTION_METHOD);
+
+        // valid one
+        upload.setCollectionMethod("other"); // Can be replaced with `manual`,`transform`,`generated`
+        List<MetaValidationError> validCollectionMethod = upload.isMetadataValidated();
+        assertThat(validCollectionMethod.size()).isEqualTo(0);
+    }
+
+    @Test
+    void testDataSource(){
+        GtfsPathwaysUpload upload = new GtfsPathwaysUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(LocalDateTime.now());
+        upload.setCollectionMethod("other");
+        upload.setPathwaysSchemaVersion("v1.0");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+        assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError noDataSourceError = errors.get(0);
+        assertThat(noDataSourceError.getCode()).isEqualTo(NO_DATA_SOURCE);
+        // Invalid datasource
+        upload.setDataSource("testdatasource");
+        List<MetaValidationError> dsErrors = upload.isMetadataValidated();
+        assertThat(dsErrors.size()).isNotEqualTo(0);
+        MetaValidationError invalidDatasourceError = dsErrors.get(0);
+        assertThat(invalidDatasourceError.getCode()).isEqualTo(INVALID_DATA_SOURCE);
+
+        // valid datasource
+        upload.setDataSource("3rdParty");
+        List<MetaValidationError> noErrors = upload.isMetadataValidated();
+        assertThat(noErrors.size()).isEqualTo(0);
+    }
+
+
+    @Test
+    void testVersionSchema(){
+        GtfsPathwaysUpload upload = new GtfsPathwaysUpload();
+        upload.setCollectedBy("collectedBy");
+        upload.setCollectionDate(LocalDateTime.now());
+        upload.setCollectionMethod("other");
+        upload.setDataSource("3rdParty");
+        List<MetaValidationError> errors = upload.isMetadataValidated();
+
+        assertThat(errors.size()).isNotEqualTo(0);
+        MetaValidationError noSchemaError = errors.get(0);
+        assertThat(noSchemaError.getCode()).isEqualTo(NO_GTFS_PATHWAY_SCHEMA);
+        // invalid schema version
+        upload.setPathwaysSchemaVersion("v0.0");
+        List<MetaValidationError> invalidSchemaErrors = upload.isMetadataValidated();
+        assertThat(invalidSchemaErrors.size()).isNotEqualTo(0);
+        MetaValidationError invalidSchemaError = invalidSchemaErrors.get(0);
+        assertThat(invalidSchemaError.getCode()).isEqualTo(INVALID_GTFS_PATHWAY_SCHEMA);
+        upload.setPathwaysSchemaVersion("v1.0");
+        List<MetaValidationError> noErrors = upload.isMetadataValidated();
+        assertThat(noErrors.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
Partially implements 
# 256
Validates the following
GTFS-Flex:
- collected_by
- collection_date
- collection_method
- data_source
- schema_version
GTFS-Pathways:
- collected_by
- collection_date
- collection_method
- data_source
- schema_version

Testing done:
Unit test converage is done with the following classes
- GTFSFlexUploadTests.java
- GTFSPathwaysUploadTests.java

External testing is done via postman script (collection available for reference)