### PR TITLE
Deploy sha tag of the docker image to app service

### DIFF
--- a/.github/workflows/dev_workflow.yaml
+++ b/.github/workflows/dev_workflow.yaml
@@ -40,8 +40,4 @@ jobs:
       with:
         app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        images: ${{ secrets.REGISTRY_DOMAIN }}/${{ secrets.REGISTRY_REPO }}:${{ github.ref_name == 'main' && 'prod' || github.ref_name }}${{ github.ref_name != 'main' && '-latest' || 'latest' }}
-
-
-
-
+        images: ${{ secrets.REGISTRY_DOMAIN }}/${{ secrets.REGISTRY_REPO }}:${{ github.sha }}


### PR DESCRIPTION
Previously, SHA_ID was used for the building and deploying to Apps Service
Now, with IaC, when we do a new build, we tag the image with "dev-latest"
We tried to deploy with "dev-latest" but this caused an issue. The "new" container image was not pulled (because same 'dev-latest' tag)
So, we changed the process to the initial one. Tag the image with "dev/stage-latest" and also the SHA_ID
When we deploy in existing infra, we use the SHA_ID
When we deploy in new infra using IaC, we use the "dev-latest" tag